### PR TITLE
Add backing and flanking calculation setters and getters

### DIFF
--- a/src/behave/surface.cpp
+++ b/src/behave/surface.cpp
@@ -258,6 +258,16 @@ double Surface::getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) co
     return LengthUnits::fromBaseUnits(surfaceFire_.getFlameLength(), flameLengthUnits);
 }
 
+double Surface::getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
+{
+  return LengthUnits::fromBaseUnits(surfaceFire_.getBackingFlameLength(), flameLengthUnits);
+}
+
+double Surface::getFlankingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
+{
+  return LengthUnits::fromBaseUnits(surfaceFire_.getFlankingFlameLength(), flameLengthUnits);
+}
+
 double Surface::getFireLengthToWidthRatio() const
 {
     return size_.getFireLengthToWidthRatio();
@@ -276,6 +286,16 @@ double Surface::getHeadingToBackingRatio() const
 double Surface::getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
 {
     return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getFirelineIntensity(), firelineIntensityUnits);
+}
+
+double Surface::getBackingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
+{
+  return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getBackingFirelineIntensity(), firelineIntensityUnits);
+}
+
+double Surface::getFlankingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
+{
+  return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getFlankingFirelineIntensity(), firelineIntensityUnits);
 }
 
 double Surface::getHeatPerUnitArea(HeatPerUnitAreaUnits::HeatPerUnitAreaUnitsEnum heatPerUnitAreaUnits) const

--- a/src/behave/surface.h
+++ b/src/behave/surface.h
@@ -70,10 +70,14 @@ public:
     double getFlankingSpreadDistance(LengthUnits::LengthUnitsEnum lengthUnits, double elapsedTime, TimeUnits::TimeUnitsEnum timeUnits);
     double getDirectionOfMaxSpread() const;
     double getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
+    double getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
+    double getFlankingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;
     double getHeadingToBackingRatio() const;
     double getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
+    double getBackingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
+    double getFlankingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getHeatPerUnitArea(HeatPerUnitAreaUnits::HeatPerUnitAreaUnitsEnum heatPerUnitAreaUnits) const;
     double getMidflameWindspeed(SpeedUnits::SpeedUnitsEnum windSpeedUnits) const;
     double getResidenceTime(TimeUnits::TimeUnitsEnum timeUnits) const;

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -161,6 +161,18 @@ void SurfaceFire::calculateFireFirelineIntensity(double forwardSpreadRate)
     firelineIntensity_ = forwardSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
 }
 
+void SurfaceFire::calculateBackingFireFirelineIntensity(double backingSpreadRate)
+{
+  double secondsPerMinute = 60.0; // for converting feet per minute to feet per second
+  backingFirelineIntensity_ = backingSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
+}
+
+void SurfaceFire::calculateFlankingFireFirelineIntensity(double flankingSpreadRate)
+{
+  double secondsPerMinute = 60.0; // for converting feet per minute to feet per second
+  flankingFirelineIntensity_ = flankingSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
+}
+
 void SurfaceFire::skipCalculationForZeroLoad()
 {
     initializeMembers();
@@ -172,6 +184,22 @@ void SurfaceFire::calculateFlameLength()
     flameLength_ = ((firelineIntensity_ < 1.0e-07)
         ? (0.0)
         : (0.45 * pow(firelineIntensity_, 0.46)));
+}
+
+void SurfaceFire::calculateBackingFlameLength()
+{
+  // Byram 1959, Albini 1976
+  backingFlameLength_ = ((backingFirelineIntensity_ < 1.0e-07)
+                         ? (0.0)
+                         : (0.45 * pow(backingFirelineIntensity_, 0.46)));
+}
+
+void SurfaceFire::calculateFlankingFlameLength()
+{
+  // Byram 1959, Albini 1976
+  flankingFlameLength_ = ((flankingFirelineIntensity_ < 1.0e-07)
+                          ? (0.0)
+                          : (0.45 * pow(flankingFirelineIntensity_, 0.46)));
 }
 
 void SurfaceFire::calculateScorchHeight()
@@ -231,9 +259,16 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
     fireLengthToWidthRatio_ = size_->getFireLengthToWidthRatio();
 
     backingSpreadRate_ = size_->getBackingSpreadRate(SpeedUnits::FeetPerMinute);
+    flankingSpreadRate_ = size_->getFlankingSpreadRate(SpeedUnits::FeetPerMinute);
 
     calculateFireFirelineIntensity(forwardSpreadRate_);
+    calculateBackingFireFirelineIntensity(backingSpreadRate_);
+    calculateFlankingFireFirelineIntensity(flankingSpreadRate_);
+
     calculateFlameLength();
+    calculateBackingFlameLength();
+    calculateFlankingFlameLength();
+
     maxFlameLength_ = getFlameLength(); // Used by SAFETY Module
     if (hasDirectionOfInterest) // If needed, calculate spread rate in arbitrary direction of interest
     {
@@ -507,9 +542,29 @@ double SurfaceFire::getFirelineIntensity() const
     return firelineIntensity_;
 }
 
+double SurfaceFire::getBackingFirelineIntensity() const
+{
+  return backingFirelineIntensity_;
+}
+
+double SurfaceFire::getFlankingFirelineIntensity() const
+{
+  return flankingFirelineIntensity_;
+}
+
 double SurfaceFire::getFlameLength() const
 {
     return flameLength_;
+}
+
+double SurfaceFire::getBackingFlameLength() const
+{
+  return backingFlameLength_;
+}
+
+double SurfaceFire::getFlankingFlameLength() const
+{
+  return flankingFlameLength_;
 }
 
 double SurfaceFire::getMaxFlameLength() const

--- a/src/behave/surfaceFire.h
+++ b/src/behave/surfaceFire.h
@@ -60,7 +60,11 @@ public:
     double getDirectionOfMaxSpread() const;
     double getEffectiveWindSpeed() const;
     double getFirelineIntensity() const;
+    double getBackingFirelineIntensity() const;
+    double getFlankingFirelineIntensity() const;
     double getFlameLength() const;
+    double getBackingFlameLength() const;
+    double getFlankingFlameLength() const;
     double getMaxFlameLength() const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;
@@ -105,7 +109,11 @@ private:
 
     void calculateResidenceTime();
     void calculateFireFirelineIntensity(double forwardSpreadRate);
+    void calculateBackingFireFirelineIntensity(double backingSpreadRate);
+    void calculateFlankingFireFirelineIntensity(double flankingSpreadRate);
     void calculateFlameLength();
+    void calculateBackingFlameLength();
+    void calculateFlankingFlameLength();
     void calculateScorchHeight();
     void calculateWindSpeedLimit();
     void calculateDirectionOfMaxSpread();
@@ -134,15 +142,20 @@ private:
     double directionOfMaxSpread_;							// Direction of max fire spread in degrees clockwise from upslope
     double noWindNoSlopeSpreadRate_;						// No-wind-no-slope fire spread rate, Rothermel 1972, equation 52
     double forwardSpreadRate_;								// Maximum rate of fire spread rate, Rothermel 1972, equation 52
+    double backingSpreadRate_;
+    double flankingSpreadRate_;
     double spreadRateInDirectionOfInterest_;				// spreadRateInDirectionOfInterest
     double heatPerUnitArea_;                                // Heat per unit area (Btu/ft^2)
     double fireLengthToWidthRatio_;
     double residenceTime_;
     double reactionIntensity_;
     double firelineIntensity_;
+    double backingFirelineIntensity_;
+    double flankingFirelineIntensity_;
     double maxFlameLength_;                                 // Flame length computed from spread rate in max direction, used in SAFETY
     double flameLength_;
-    double backingSpreadRate_;
+    double backingFlameLength_;
+    double flankingFlameLength_;
     double heatSource_;
     double scorchHeight_;
 


### PR DESCRIPTION
This PR adds setters and getters for the flanking and backing calculations:
- spread rate
- fire line intensity
- flame length