### PR TITLE
Expose some Variables from ContainSim in ContainAdapter

### DIFF
--- a/src/behave/crown.cpp
+++ b/src/behave/crown.cpp
@@ -327,16 +327,19 @@ void Crown::calculateCrownFireActiveWindSpeed()
     crownFireActiveWindSpeed_ = uMid / 0.4;         // 20-ft wind speed (ft/min) for waf=0.4
 }
 
-double Crown::getCrownCriticalFireSpreadRate() const {
-  return crownCriticalFireSpreadRate_;
+double Crown::getCrownCriticalFireSpreadRate(SpeedUnits::SpeedUnitsEnum spreadRateUnits) const
+{
+  return SpeedUnits::fromBaseUnits(crownCriticalFireSpreadRate_, spreadRateUnits);
 }
 
-double Crown::getCrownCriticalSurfaceFirelineIntensity() {
-  return crownCriticalSurfaceFirelineIntensity_;
+double Crown::getCrownCriticalSurfaceFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
+{
+  return FirelineIntensityUnits::fromBaseUnits(crownCriticalSurfaceFirelineIntensity_, firelineIntensityUnits);
 }
 
-double Crown::getCrownCriticalSurfaceFlameLength() const {
-  return crownCriticalSurfaceFirelineIntensity_;
+double Crown::getCrownCriticalSurfaceFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
+{
+  return LengthUnits::fromBaseUnits(crownFlameLength_, flameLengthUnits);
 }
 
 double Crown::getCrownFireActiveRatio() const {

--- a/src/behave/crown.cpp
+++ b/src/behave/crown.cpp
@@ -331,6 +331,10 @@ double Crown::getCrownCriticalFireSpreadRate() const {
   return crownCriticalFireSpreadRate_;
 }
 
+double Crown::getCrownCriticalSurfaceFirelineIntensity() {
+  return crownCriticalSurfaceFirelineIntensity_;
+}
+
 double Crown::getCrownCriticalSurfaceFlameLength() const {
   return crownCriticalSurfaceFirelineIntensity_;
 }
@@ -341,10 +345,6 @@ double Crown::getCrownFireActiveRatio() const {
 
 double Crown::getCrownTransitionRatio() const {
   return crownFireTransitionRatio_;
-}
-
-double Crown::getCrownCriticalSurfaceFirelineIntensity() {
-  return crownCriticalSurfaceFirelineIntensity_;
 }
 
 double Crown::getCrownFireSpreadRate(SpeedUnits::SpeedUnitsEnum spreadRateUnits) const

--- a/src/behave/crown.cpp
+++ b/src/behave/crown.cpp
@@ -119,14 +119,14 @@ void Crown::doCrownRunRothermel()
 
     surfaceFuel_.setCrownRatio(crownRatio);
 
-    // Step 1: Do surface run and store values needed for further calculations 
+    // Step 1: Do surface run and store values needed for further calculations
     surfaceFuel_.setWindAdjustmentFactorCalculationMethod(WindAdjustmentFactorCalculationMethod::UseCrownRatio);
-    surfaceFuel_.doSurfaceRunInDirectionOfMaxSpread(); // Crown ROS output given in direction of max spread 
+    surfaceFuel_.doSurfaceRunInDirectionOfMaxSpread(); // Crown ROS output given in direction of max spread
     surfaceFireHeatPerUnitArea_ = surfaceFuel_.getHeatPerUnitArea(HeatPerUnitAreaUnits::BtusPerSquareFoot);
     surfaceFirelineIntensity_ = surfaceFuel_.getFirelineIntensity(FirelineIntensityUnits::BtusPerFootPerSecond);
     surfaceFireSpreadRate_ = surfaceFuel_.getSpreadRate(SpeedUnits::FeetPerMinute); // Byram
     surfaceFireFlameLength_ = surfaceFuel_.getFlameLength(LengthUnits::Feet); // Byram
-    
+
     // Step 2: Create the crown fuel model (fire behavior fuel model 10)
     crownFuel_ = surfaceFuel_;
     crownFuel_.setWindAdjustmentFactorCalculationMethod(WindAdjustmentFactorCalculationMethod::UserInput);
@@ -242,7 +242,7 @@ void Crown::calculateCrownFractionBurned()
     // Using these parameters:
     // surfaceFireSpreadRate_: the "actual" surface fire spread rate (ft/min).
     // surfaceFireCriticalSpreadRate_: surface fire spread rate required to initiate torching/crowning (ft/min).
-    // crowningSurfaceFireRos_: Surface fire spread rate at which the active crown fire spread rate is fully achieved 
+    // crowningSurfaceFireRos_: Surface fire spread rate at which the active crown fire spread rate is fully achieved
     // and the crown fraction burned is 1.
 
     double numerator = surfaceFireSpreadRate_ - surfaceFireCriticalSpreadRate_;
@@ -325,6 +325,26 @@ void Crown::calculateCrownFireActiveWindSpeed()
     double a = ((r10 / ros0) - 1.0 - slopeFactor) / windK;
     double uMid = pow(a, windBInv);                 // midflame wind speed (ft/min)
     crownFireActiveWindSpeed_ = uMid / 0.4;         // 20-ft wind speed (ft/min) for waf=0.4
+}
+
+double Crown::getCrownCriticalFireSpreadRate() const {
+  return crownCriticalFireSpreadRate_;
+}
+
+double Crown::getCrownCriticalSurfaceFlameLength() const {
+  return crownCriticalSurfaceFirelineIntensity_;
+}
+
+double Crown::getCrownFireActiveRatio() const {
+  return crownFireActiveRatio_;
+}
+
+double Crown::getCrownTransitionRatio() const {
+  return crownFireTransitionRatio_;
+}
+
+double Crown::getCrownCriticalSurfaceFirelineIntensity() {
+  return crownCriticalSurfaceFirelineIntensity_;
 }
 
 double Crown::getCrownFireSpreadRate(SpeedUnits::SpeedUnitsEnum spreadRateUnits) const
@@ -600,7 +620,7 @@ void Crown::calculateFireTypeRothermel()
         {
             fireType_ = FireType::Surface; // Surface fire
         }
-        else // crownFireActiveRatio_ >= 1.0 
+        else // crownFireActiveRatio_ >= 1.0
         {
             fireType_ = FireType::ConditionalCrownFire; // Conditional crown fire
         }

--- a/src/behave/crown.h
+++ b/src/behave/crown.h
@@ -102,6 +102,12 @@ public:
     double getCriticalOpenWindSpeed(SpeedUnits::SpeedUnitsEnum speedUnits) const;
     double getCrownFractionBurned() const;
 
+    double getCrownCriticalFireSpreadRate(SpeedUnits::SpeedUnitsEnum spreadRateUnits) const;
+    double getCrownCriticalSurfaceFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
+    double getCrownCriticalSurfaceFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
+    double getCrownFireActiveRatio() const;
+    double getCrownTransitionRatio() const;
+
     // Fuel Model Getter Methods
     std::string getFuelCode(int fuelModelNumber) const;
     std::string getFuelName(int fuelModelNumber) const;
@@ -184,11 +190,6 @@ public:
     double getCanopyCover(CoverUnits::CoverUnitsEnum canopyCoverUnits) const;
     double getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeighUnits) const;
     double getCrownRatio() const;
-    double getCrownCriticalFireSpreadRate() const;
-    double getCrownCriticalSurfaceFirelineIntensity();
-    double getCrownCriticalSurfaceFlameLength() const;
-    double getCrownFireActiveRatio() const;
-    double getCrownTransitionRatio() const;
 
 protected:
     struct CrownModelType

--- a/src/behave/crown.h
+++ b/src/behave/crown.h
@@ -188,10 +188,7 @@ public:
     double getCrownCriticalSurfaceFirelineIntensity();
     double getCrownCriticalSurfaceFlameLength() const;
     double getCrownFireActiveRatio() const;
-    double getCrownFireSpreadRate() const;
     double getCrownTransitionRatio() const;
-
-
 
 protected:
     struct CrownModelType

--- a/src/behave/crown.h
+++ b/src/behave/crown.h
@@ -29,7 +29,7 @@
 ******************************************************************************/
 
 // TODO: Add unit conversions for energy and incorporate into calculateCrownCriticalSurfaceFireIntensity() - WMC 11/16
-// TODO: Allow for use case in which Crown is run completely without Surface, will involve allowing direct input of HPUA 
+// TODO: Allow for use case in which Crown is run completely without Surface, will involve allowing direct input of HPUA
 //       and surface flame length, as well as setting all other pertinent surface inputs in Crown's copy of Surface - WMC 11/16
 
 #ifndef CROWN_H
@@ -47,7 +47,7 @@ struct FireType
     {
         Surface = 0,    // surface fire with no torching or crown fire spread.
         Torching = 1,   // surface fire with torching.
-        ConditionalCrownFire = 2, // active crown fire possible if the fire transitions to the overstory        
+        ConditionalCrownFire = 2, // active crown fire possible if the fire transitions to the overstory
         Crowning = 3    // active crown fire, fire is spreading through the canopy.
     };
 };
@@ -184,6 +184,14 @@ public:
     double getCanopyCover(CoverUnits::CoverUnitsEnum canopyCoverUnits) const;
     double getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeighUnits) const;
     double getCrownRatio() const;
+    double getCrownCriticalFireSpreadRate() const;
+    double getCrownCriticalSurfaceFirelineIntensity();
+    double getCrownCriticalSurfaceFlameLength() const;
+    double getCrownFireActiveRatio() const;
+    double getCrownFireSpreadRate() const;
+    double getCrownTransitionRatio() const;
+
+
 
 protected:
     struct CrownModelType


### PR DESCRIPTION
These are some variables needed to construct the contain diagrams. I initially thought I could just save the instance of the `containSim` created during the `doContainRun` inside a protected member variable (`sim_`) in `ContainAdapter` but I was getting an error described below:

error: constructor for 'ContainAdapter' must explicitly initialize the member 'sim_' which does not have a default constructor.

For now this is my solution, to add setters for individual variables inside `doContainRun` but if you know of a better way without having to write all these setters that would be great.