### PR TITLE
expose containsim variables

### DIFF
--- a/src/behave/ContainAdapter.cpp
+++ b/src/behave/ContainAdapter.cpp
@@ -181,6 +181,15 @@ void ContainAdapter::doContainRun()
         // Do Contain simulation
         containSim.run();
 
+        // Store Values from ContainSim For Access in SIGContainAdapter
+        m_size       = containSim.firePoints();
+        m_x          = containSim.firePerimeterX();
+        m_y          = containSim.firePerimeterY();
+        m_reportHead = containSim.fireHeadAtReport();
+        m_reportBack = containSim.fireBackAtReport();
+        m_attackHead = containSim.fireHeadAtAttack();
+        m_attackBack = containSim.fireBackAtAttack();
+
         // Get results from Contain simulation
         finalCost_ = containSim.finalFireCost();
         finalFireLineLength_ = LengthUnits::toBaseUnits(containSim.finalFireLine(), LengthUnits::Chains);

--- a/src/behave/ContainAdapter.h
+++ b/src/behave/ContainAdapter.h
@@ -168,6 +168,15 @@ protected:
     double finalContainmentArea_; // Final containment area at containment or escape
     double finalTime_; // Containment or escape time since report
     ContainAdapterEnums::ContainStatus::ContainStatusEnum containmentStatus_;
+
+    // ContainSim Outputs
+    double* m_x;          //!< Array of perimeter x coordinates (ch)
+    double* m_y;          //!< Array of perimeter y coordinates (ch)
+    int m_size;           //!< Size of the m_x and m_y arrays
+    double m_reportHead;  //!< Fire head position at report time (ch)
+    double m_reportBack;  //!< Fire back position at report time (ch)
+    double m_attackHead;  //!< Fire head position at first attack (ch)
+    double m_attackBack;  //!< Fire back position at first attack (ch)
 };
 
 #endif //CONTAINADAPTER_H


### PR DESCRIPTION
These are some variables needed to construct the contain diagrams. I initially thought I could just save the instance of the containSim created during the doContainRun inside a protected member variable (sim_) in ContainAdapter but I was getting an error described below:

error: constructor for 'ContainAdapter' must explicitly initialize the member 'sim_' which does not have a default constructor.

For now this is my solution, to add setters for individual variables inside doContainRun but if you know of a better way without having to write all these setters that would be great.