### PR TITLE
Add HectoPascals (hPa), default to hPa for VPD output

### DIFF
--- a/src/behave/behaveUnits.cpp
+++ b/src/behave/behaveUnits.cpp
@@ -396,6 +396,7 @@ double LoadingUnits::fromBaseUnits(double value, LoadingUnitsEnum units)
 
 double PressureUnits::toBaseUnits(double value, PressureUnitsEnum units) {
   // Pressure to base units constants
+  const double HECTOPASCAL_TO_PASCAL     = 1e2;
   const double KILOPASCAL_TO_PASCAL      = 1e3;
   const double MEGAPASCAL_TO_PASCAL      = 1e6;
   const double GIGAPASCAL_TO_PASCAL      = 1e9;
@@ -409,6 +410,11 @@ double PressureUnits::toBaseUnits(double value, PressureUnitsEnum units) {
       case Pascal:
       {
           // Already in base, nothing to do
+          break;
+      }
+      case HectoPascal:
+      {
+          value /= HECTOPASCAL_TO_PASCAL;
           break;
       }
       case KiloPascal:
@@ -453,6 +459,7 @@ double PressureUnits::toBaseUnits(double value, PressureUnitsEnum units) {
 
 double PressureUnits::fromBaseUnits(double value, PressureUnitsEnum units) {
   // Pressure to base units constants
+  const double HECTOPASCAL_TO_PASCAL     = 1e2;
   const double KILOPASCAL_TO_PASCAL      = 1e3;
   const double MEGAPASCAL_TO_PASCAL      = 1e6;
   const double GIGAPASCAL_TO_PASCAL      = 1e9;
@@ -466,6 +473,11 @@ double PressureUnits::fromBaseUnits(double value, PressureUnitsEnum units) {
       case Pascal:
       {
           // Already in base, nothing to do
+          break;
+      }
+      case HectoPascal:
+      {
+          value *= HECTOPASCAL_TO_PASCAL;
           break;
       }
       case KiloPascal:

--- a/src/behave/behaveUnits.h
+++ b/src/behave/behaveUnits.h
@@ -93,6 +93,7 @@ struct PressureUnits
     enum PressureUnitsEnum
     {
         Pascal,              // base loading unit
+        HectoPascal,         // hPa
         KiloPascal,          // kPa
         MegaPascal,          // MPa
         GigaPascal,          // GPa

--- a/src/behave/vaporPressureDeficitCalculator.cpp
+++ b/src/behave/vaporPressureDeficitCalculator.cpp
@@ -57,8 +57,8 @@ void VaporPressureDeficitCalculator::runCalculation() {
   // Calculate vapor pressure deficit
   vaporPressureDeficit_ = saturationVaporPressure - actualVaporPressure;
 
-  // Store in base units (Pa -> hPa)
-  vaporPressureDeficit_ = PressureUnits::toBaseUnits(vaporPressureDeficit_, PressureUnits::HectoPascal);
+  // Store in base units (kPa -> Pa)
+  vaporPressureDeficit_ = PressureUnits::toBaseUnits(vaporPressureDeficit_, PressureUnits::KiloPascal);
 }
 
 // Getters

--- a/src/behave/vaporPressureDeficitCalculator.cpp
+++ b/src/behave/vaporPressureDeficitCalculator.cpp
@@ -57,8 +57,8 @@ void VaporPressureDeficitCalculator::runCalculation() {
   // Calculate vapor pressure deficit
   vaporPressureDeficit_ = saturationVaporPressure - actualVaporPressure;
 
-  // Store in base units (kPa -> Pa)
-  vaporPressureDeficit_ = PressureUnits::toBaseUnits(vaporPressureDeficit_, PressureUnits::KiloPascal);
+  // Store in base units (Pa -> hPa)
+  vaporPressureDeficit_ = PressureUnits::toBaseUnits(vaporPressureDeficit_, PressureUnits::HectoPascal);
 }
 
 // Getters


### PR DESCRIPTION
Faith Anne requested that the VPD calculator use HectoPascals (hPa) in lieu of KiloPascals (kPa). This work completes that task on the Behave Library side.