### PR TITLE
[BHP1-834] re-assign treeCrownVolumeScorced and treeCrownLengthScorched if not used to compute mortality

### DIFF
--- a/src/behave/mortality.cpp
+++ b/src/behave/mortality.cpp
@@ -696,6 +696,8 @@ double  Mortality::calculateMortalityCrownScorch()
             {
                 P = 1.0 / (1.0 + exp((0.0858 * DBH * 2.54) - (0.118 * CH * 2.54 * 12.0) - 2.157));
             }
+            treeCrownVolumeScorched_ = -1;
+            treeCrownLengthScorched_ = -1;
             break;
         }
         //...................................................
@@ -737,51 +739,61 @@ double  Mortality::calculateMortalityCrownScorch()
         case 10:
         {
             P = Whitefir(CSL); // ABICON                            
+            treeCrownVolumeScorched_ = -1;
             break;
         }
         case 11:
         {
             P = SubalpineFir(crownVolumeScorchedPercent); // ABILAS                            
+            treeCrownLengthScorched_ = -1;
             break;
         }
         case 12:
         {
             P = IncenseCedar(CSL); // LIBDEC                            
+            treeCrownVolumeScorched_ = -1;
             break;
         }
         case 14:
         {
             P = WesternLarch(crownVolumeScorchedPercent, DBH); // LAROCC                            
+            treeCrownLengthScorched_ = -1;
             break;
         }
         case 15:
         {
             P = EngelmannSpruce(crownVolumeScorchedPercent); // PICENG                            
+            treeCrownLengthScorched_ = -1;
             break;
         }
         case 16:
         {
             P = RedFir(CSL); // ABIMAG                          
+            treeCrownVolumeScorched_ = -1;
             break;
         }
         case 17:
         {
             P = WhitebarkPine(crownVolumeScorchedPercent, DBH); // PINALB                      
+            treeCrownLengthScorched_ = -1;
             break;
         }
         case 18:
         {
             P = SugarPine(CSL);
+            treeCrownVolumeScorched_ = -1;
             break;
         }
         case 19:
         {
             P = PonderosaJeffreyPine(crownVolumeScorchedPercent);
+            treeCrownLengthScorched_ = -1;
             break;
         }
         case 20:
         {
             P = DouglasFir(crownVolumeScorchedPercent);
+            treeCrownLengthScorched_ = -1;
             break;
         }
         // Change 9-6-2016 - new Black Hills PiPo, see Duncan Lutes's .docx document saved in fofem project folder 
@@ -790,12 +802,16 @@ double  Mortality::calculateMortalityCrownScorch()
             f = mortalityInputs_.getCrownRatio(); // crown ratio 
             CBH = mortalityInputs_.getTreeHeight(LengthUnits::Feet) - (mortalityInputs_.getTreeHeight(LengthUnits::Feet) * f);
             P = Eq21_BlkHilPiPo(mortalityInputs_.getTreeHeight(LengthUnits::Feet), CBH, mortalityInputs_.getDBH(LengthUnits::Feet), scorchHeight, blackHillsFlameLength);
+            treeCrownLengthScorched_ = -1;
+            treeCrownVolumeScorched_ = -1;
             break;
         }
         default:
         {
             //sprintf(cr_ErrMes, "Equation Not implemented,  Equ Num: %d\n", i_MortEqu);
             P = 0;
+            treeCrownLengthScorched_ = -1;
+            treeCrownVolumeScorched_ = -1;
             return -1.0;
             break;
         }
@@ -1959,14 +1975,14 @@ double Mortality::getKilledTrees() const
     return killedTrees_;
 }
 
-double Mortality::getTreeCrownLengthScorched(FractionUnits::FractionUnitsEnum fractionUnits) const
+double Mortality::getTreeCrownLengthScorched(LengthUnits::LengthUnitsEnum lengthUnits) const
 {
-  return FractionUnits::fromBaseUnits(treeCrownLengthScorched_, fractionUnits);
+    return LengthUnits::fromBaseUnits(treeCrownLengthScorched_, lengthUnits);
 }
 
 double Mortality::getTreeCrownVolumeScorched(FractionUnits::FractionUnitsEnum fractionUnits) const
 {
-  return FractionUnits::fromBaseUnits(treeCrownVolumeScorched_, fractionUnits);
+    return FractionUnits::fromBaseUnits(treeCrownVolumeScorched_, fractionUnits);
 }
 
 double Mortality::getBasalAreaPrefire() const

--- a/src/behave/mortality.cpp
+++ b/src/behave/mortality.cpp
@@ -27,6 +27,8 @@ Mortality::Mortality(SpeciesMasterTable& speciesMasterTable)
     {  -1,        0,         0,       0 }
 }
 {
+    treeCrownLengthScorched_ = -1;
+    treeCrownVolumeScorched_ = -1;
     speciesMasterTable_ = &speciesMasterTable;
     speciesMasterTable_->initializeMasterTable();
     initializeOutputs();

--- a/src/behave/mortality.h
+++ b/src/behave/mortality.h
@@ -109,7 +109,7 @@ public:
     double getProbabilityOfMortality(FractionUnits::FractionUnitsEnum probabilityUnits) const;   // Individual Species Probility of Mortality
     double getTotalPrefireTrees() const;        // Total Prefire Trees               
     double getKilledTrees() const;
-    double getTreeCrownLengthScorched(FractionUnits::FractionUnitsEnum fractionUnits) const;
+    double getTreeCrownLengthScorched(LengthUnits::LengthUnitsEnum lengthUnits) const;
     double getTreeCrownVolumeScorched(FractionUnits::FractionUnitsEnum fractionUnits) const;
 
     double getBasalAreaPrefire() const;         // Prefire Basal Area                


### PR DESCRIPTION
-------

## Purpose

In `calculateMortalityCrownScorch`, if the equation number of the tree species does not use `treeCrownLengthScorched` or `treeCrownVolumeScorced`, set it to -1 so that user knows which one was used.

## Related Issues
BHP1-834

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing