### PR TITLE
[BHP1-986] Update crownRatio setters and getters to also take in a units param

### DIFF
--- a/src/behave/client.cpp
+++ b/src/behave/client.cpp
@@ -230,7 +230,7 @@ int main()
         double testGetDBH = behave.mortality.getDBH(LengthUnits::Feet);
         behave.mortality.setTreeHeight(35.0, LengthUnits::Feet);
         double testGetTreeHeight = behave.mortality.getTreeHeight(LengthUnits::Feet);
-        behave.mortality.setCrownRatio(0.30); // A value between 0.0 and 1.0 is valid
+        behave.mortality.setCrownRatio(0.30, FractionUnits::Fraction); // A value between 0.0 and 1.0 is valid
         behave.mortality.setCrownDamage(25.0);
         behave.mortality.setCambiumKillRating(3.2);
         behave.mortality.setBeetleDamage(BeetleDamage::yes);
@@ -252,7 +252,7 @@ int main()
                 {
                     std::cout << "Error, missing required input " << fieldNameStrings[i] << "\n";
                 }
-                if((currentRequiredFieldName == RequiredFieldNames::crown_ratio) && behave.mortality.getCrownRatio() < 0)
+                if((currentRequiredFieldName == RequiredFieldNames::crown_ratio) && behave.mortality.getCrownRatio(FractionUnits::Fraction) < 0)
                 {
                     std::cout << "Error, missing required input " << fieldNameStrings[i] << "\n";
                 }

--- a/src/behave/client.cpp
+++ b/src/behave/client.cpp
@@ -58,7 +58,7 @@ int main()
     // Single fuel model test
     behave.surface.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody,
         FractionUnits::Percent, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode, slope, SlopeUnits::Degrees,
-        aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+                                       aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
 
     behave.surface.setIsUsingChaparral(true);
     behave.surface.setChaparralFuelBedDepth(3, LengthUnits::Feet);
@@ -121,7 +121,7 @@ int main()
         behave.surface.updateSurfaceInputsForTwoFuelModels(firstFuelModelNumber, secondFuelModelNumber, moistureOneHour, moistureTenHour,
             moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, FractionUnits::Percent, windSpeed, windSpeedUnits, windHeightInputMode,
             windDirection, windAndSpreadOrientationMode, firstFuelModelCoverage, firstFuelModelCoverageUnits, twoFuelModelsMethod, slope,
-            slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+                                                           slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
         behave.surface.doSurfaceRunInDirectionOfInterest(directionOfInterest, surfaceFireSpreadDirectionMode);
         spreadRate = behave.surface.getSpreadRate(SpeedUnits::ChainsPerHour);
         //spreadRate = floor(spreadRate * 10 + 0.5) / 10;
@@ -159,7 +159,7 @@ int main()
     // Single fuel model test
     behave.surface.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, 
         FractionUnits::Percent, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode, slope, SlopeUnits::Degrees,
-        aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+                                       aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
     behave.surface.doSurfaceRunInDirectionOfInterest(directionOfInterest, surfaceFireSpreadDirectionMode);
     spreadRate = behave.surface.getSpreadRate(SpeedUnits::ChainsPerHour);
     //flameLength = floor((behave.getFlameLength()) * 10 + 0.5) / 10;

--- a/src/behave/crown.cpp
+++ b/src/behave/crown.cpp
@@ -117,7 +117,7 @@ void Crown::doCrownRunRothermel()
         crownRatio = (canopyHeight - canopyBaseHeight) / canopyHeight;
     }
 
-    surfaceFuel_.setCrownRatio(crownRatio);
+    surfaceFuel_.setCrownRatio(crownRatio, FractionUnits::Fraction);
 
     // Step 1: Do surface run and store values needed for further calculations 
     surfaceFuel_.setWindAdjustmentFactorCalculationMethod(WindAdjustmentFactorCalculationMethod::UseCrownRatio);
@@ -174,7 +174,7 @@ void Crown::doCrownRunScottAndReinhardt()
     double canopyBaseHeight = crownInputs_.getCanopyBaseHeight(LengthUnits::Feet);
     double crownRatio = (canopyHeight - canopyBaseHeight) / canopyHeight;
 
-    surfaceFuel_.setCrownRatio(crownRatio);
+    surfaceFuel_.setCrownRatio(crownRatio, FractionUnits::Fraction);
 
     // Step 1: Do surface run and store values needed for further calculations
     const double windSpeed = surfaceFuel_.getWindSpeed(SpeedUnits::FeetPerMinute, WindHeightInputMode::TwentyFoot);
@@ -637,12 +637,12 @@ void Crown::updateCrownInputs(int fuelModelNumber, double moistureOneHour, doubl
     double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode,
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope,
     SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight,
-    double canopyBaseHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, double canopyBulkDensity,
-    DensityUnits::DensityUnitsEnum densityUnits)
+    double canopyBaseHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits,
+    double canopyBulkDensity, DensityUnits::DensityUnitsEnum densityUnits)
 {
     surfaceFuel_.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection,
-        windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits, canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     crownInputs_.updateCrownInputs(canopyBaseHeight, canopyHeightUnits, canopyBulkDensity, densityUnits, moistureFoliar, moistureUnits);
 }
 
@@ -757,12 +757,12 @@ void Crown::updateCrownsSurfaceInputs(int fuelModelNumber, double moistureOneHou
     SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode,
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode,
     double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits,
-    double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     surfaceFuel_.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour,
         moistureLiveHerbaceous, moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode,
         windDirection, windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits,
-        canopyHeight, canopyHeightUnits, crownRatio);
+        canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
 }
 
 void  Crown::setCanopyCover(double canopyCover, FractionUnits::FractionUnitsEnum coverUnits)
@@ -775,9 +775,9 @@ void  Crown::setCanopyHeight(double canopyHeight, LengthUnits::LengthUnitsEnum c
     surfaceFuel_.setCanopyHeight(canopyHeight, canopyHeightUnits);
 }
 
-void  Crown::setCrownRatio(double crownRatio)
+void  Crown::setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
-    surfaceFuel_.setCrownRatio(crownRatio);
+    surfaceFuel_.setCrownRatio(crownRatio, FractionUnits::Fraction);
 }
 
 void  Crown::setFuelModelNumber(int fuelModelNumber)
@@ -1030,9 +1030,9 @@ double Crown::getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeighUnits) con
     return surfaceFuel_.getCanopyHeight(canopyHeighUnits);
 }
 
-double Crown::getCrownRatio() const
+double Crown::getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const
 {
-    return surfaceFuel_.getCrownRatio();
+    return surfaceFuel_.getCrownRatio(crownRatioUnits);
 }
 
 double Crown::getCanopyBaseHeight(LengthUnits::LengthUnitsEnum canopyHeightUnits) const

--- a/src/behave/crown.h
+++ b/src/behave/crown.h
@@ -75,7 +75,7 @@ public:
         WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode,
         double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits,
-        double canopyHeight, double canopyBaseHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio,
+        double canopyHeight, double canopyBaseHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits,
         double canopyBulkDensity, DensityUnits::DensityUnitsEnum densityUnits);
     void setCanopyBaseHeight(double canopyBaseHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits);
     void setCanopyBulkDensity(double canopyBulkDensity, DensityUnits::DensityUnitsEnum densityUnits);
@@ -130,10 +130,10 @@ public:
         SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope,
         SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits, double canopyHeight,
-        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setCanopyCover(double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits);
     void setCanopyHeight(double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits);
-    void setCrownRatio(double crownRatio);
+    void setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setFuelModelNumber(int fuelModelNumber);
     void setMoistureOneHour(double moistureOneHour, FractionUnits::FractionUnitsEnum moistureUnits);
     void setMoistureTenHour(double moistureTenHour, FractionUnits::FractionUnitsEnum moistureUnits);
@@ -185,7 +185,7 @@ public:
     double getAspect() const;
     double getCanopyCover(FractionUnits::FractionUnitsEnum canopyCoverUnits) const;
     double getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeighUnits) const;
-    double getCrownRatio() const;
+    double getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const;
 
 protected:
     struct CrownModelType

--- a/src/behave/mortality.cpp
+++ b/src/behave/mortality.cpp
@@ -163,9 +163,9 @@ void Mortality::setTreeHeight(double treeHeight, LengthUnits::LengthUnitsEnum tr
     mortalityInputs_.setTreeHeight(treeHeight, treeHeightUnits);
 }
 
-void Mortality::setCrownRatio(double crownRatio)
+void Mortality::setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
-    mortalityInputs_.setCrownRatio(crownRatio);
+    mortalityInputs_.setCrownRatio(crownRatio, crownRatioUnits);
 }
 
 void Mortality::setCrownDamage(double crownDamage)
@@ -250,9 +250,9 @@ double Mortality::getTreeHeight(LengthUnits::LengthUnitsEnum treeHeightUnits) co
     return mortalityInputs_.getTreeHeight(treeHeightUnits);
 }
 
-double Mortality::getCrownRatio() const
+double Mortality::getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const
 {
-    return mortalityInputs_.getCrownRatio();
+    return mortalityInputs_.getCrownRatio(crownRatioUnits);
 }
 
 double Mortality::getCrownDamage() const
@@ -606,7 +606,7 @@ double  Mortality::calculateMortalityCrownScorch()
     mortalityInputs_.setBarkThickness(calculateBarkThickness(), LengthUnits::Inches);
 
     treeHeight = mortalityInputs_.getTreeHeight(LengthUnits::Feet); // Note-1                        
-    HCR = treeHeight * (mortalityInputs_.getCrownRatio());
+    HCR = treeHeight * (mortalityInputs_.getCrownRatio(FractionUnits::Fraction));
     treeCrownLengthScorched_ = scorchHeight - (treeHeight - HCR);
 
     if(treeCrownLengthScorched_ <= 0.0)
@@ -806,7 +806,7 @@ double  Mortality::calculateMortalityCrownScorch()
         // Change 9-6-2016 - new Black Hills PiPo, see Duncan Lutes's .docx document saved in fofem project folder 
         case 21:
         {
-            f = mortalityInputs_.getCrownRatio(); // crown ratio 
+            f = mortalityInputs_.getCrownRatio(FractionUnits::Fraction); // crown ratio 
             CBH = mortalityInputs_.getTreeHeight(LengthUnits::Feet) - (mortalityInputs_.getTreeHeight(LengthUnits::Feet) * f);
             P = Eq21_BlkHilPiPo(mortalityInputs_.getTreeHeight(LengthUnits::Feet), CBH, mortalityInputs_.getDBH(LengthUnits::Feet), scorchHeight, blackHillsFlameLength);
             treeCrownLengthScorched_ = -1;

--- a/src/behave/mortality.h
+++ b/src/behave/mortality.h
@@ -38,7 +38,7 @@ public:
     void setTreeDensityPerUnitArea(double numberOfTrees, AreaUnits::AreaUnitsEnum areaUnits);
     void setDBH(double dbh, LengthUnits::LengthUnitsEnum diameterUnits);
     void setTreeHeight(double treeHeight, LengthUnits::LengthUnitsEnum treeHeightUnits);
-    void setCrownRatio(double crownRatio);
+    void setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setCrownDamage(double crownDamage);
     void setCambiumKillRating(double cambiumKillRating);
     void setBeetleDamage(BeetleDamage beetleDamage);
@@ -61,7 +61,7 @@ public:
     double getTreeDensityPerUnitArea(AreaUnits::AreaUnitsEnum areaUnits) const;
     double getDBH(LengthUnits::LengthUnitsEnum diameterUnits) const;
     double getTreeHeight(LengthUnits::LengthUnitsEnum treeHeightUnits) const;
-    double getCrownRatio() const;
+    double getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const;
     double getCrownDamage() const;
     CrownDamageEquationCode getCrownDamageEquationCode() const;
     CrownDamageType getCrownDamageType() const;

--- a/src/behave/mortality_inputs.cpp
+++ b/src/behave/mortality_inputs.cpp
@@ -131,9 +131,9 @@ void MortalityInputs::setTreeHeight(double treeHeight, LengthUnits::LengthUnitsE
     treeHeight_ = LengthUnits::toBaseUnits(treeHeight, treeHeightUnits);
 }
 
-void MortalityInputs::setCrownRatio(double crownRatio)
+void MortalityInputs::setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
-    crownRatio_ = crownRatio;
+    crownRatio_ = FractionUnits::toBaseUnits(crownRatio, crownRatioUnits);
 }
 
 void MortalityInputs::setCrownDamage(double crownDamage)
@@ -245,9 +245,9 @@ double MortalityInputs::getTreeHeight(LengthUnits::LengthUnitsEnum treeHeightUni
     return LengthUnits::fromBaseUnits(treeHeight_, treeHeightUnits);
 }
 
-double MortalityInputs::getCrownRatio() const
+double MortalityInputs::getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const
 {
-    return crownRatio_;
+    return FractionUnits::fromBaseUnits(crownRatio_, crownRatioUnits);
 }
 
 double MortalityInputs::getCrownDamage() const

--- a/src/behave/mortality_inputs.h
+++ b/src/behave/mortality_inputs.h
@@ -53,7 +53,7 @@ public:
     void setTreeDensityPerUnitArea(double numberOfTrees, AreaUnits::AreaUnitsEnum areaUnits);
     void setDBH(double dbh, LengthUnits::LengthUnitsEnum diameterUnits);
     void setTreeHeight(double treeHeight, LengthUnits::LengthUnitsEnum treeHeightUnits);
-    void setCrownRatio(double crownRatio);
+    void setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setCrownDamage(double crownDamage);
     void setCambiumKillRating(double cambiumKillRating);
     void setBeetleDamage(BeetleDamage beetleDamage);
@@ -78,7 +78,7 @@ public:
     double getTreeDensityPerUnitArea(AreaUnits::AreaUnitsEnum areaUnits) const;
     double getDBH(LengthUnits::LengthUnitsEnum diameterUnits) const;
     double getTreeHeight(LengthUnits::LengthUnitsEnum treeHeightUnits) const;
-    double getCrownRatio() const;
+    double getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const;
     double getCrownDamage() const;
     double getCambiumKillRating() const;
     BeetleDamage getBeetleDamage() const;

--- a/src/behave/surface.cpp
+++ b/src/behave/surface.cpp
@@ -388,9 +388,9 @@ void Surface::setCanopyHeight(double canopyHeight, LengthUnits::LengthUnitsEnum 
     surfaceInputs_.setCanopyHeight(canopyHeight, canopyHeightUnits);
 }
 
-void Surface::setCrownRatio(double crownRatio)
+void Surface::setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
-    surfaceInputs_.setCrownRatio(crownRatio);
+    surfaceInputs_.setCrownRatio(crownRatio, crownRatioUnits);
 }
 
 void Surface::setElapsedTime(double elapsedTime, TimeUnits::TimeUnitsEnum timeUnits) {
@@ -704,9 +704,9 @@ double Surface::getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeightUnits) 
     return surfaceInputs_.getCanopyHeight(canopyHeightUnits);
 }
 
-double Surface::getCrownRatio() const
+double Surface::getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const
 {
-    return surfaceInputs_.getCrownRatio();
+    return surfaceInputs_.getCrownRatio(crownRatioUnits);
 }
 
 WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum Surface::getWindAndSpreadOrientationMode() const
@@ -1044,11 +1044,11 @@ void Surface::updateSurfaceInputs(int fuelModelNumber, double moistureOneHour, d
     SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode,
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode,
     double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight,
-    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     surfaceInputs_.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode,
-        slope, slopeUnits, aspect, canopyCover, canopyUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        slope, slopeUnits, aspect, canopyCover, canopyUnits, canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     surfaceFire_.calculateMidflameWindSpeed();
 }
 
@@ -1059,12 +1059,13 @@ void Surface::updateSurfaceInputsForTwoFuelModels(int firstfuelModelNumber, int 
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double firstFuelModelCoverage,
     FractionUnits::FractionUnitsEnum firstFuelModelCoverageUnits, TwoFuelModelsMethod::TwoFuelModelsMethodEnum twoFuelModelsMethod,
     double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover,
-    FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits,
+    double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     surfaceInputs_.updateSurfaceInputsForTwoFuelModels(firstfuelModelNumber, secondFuelModelNumber, moistureOneHour, moistureTenHour,
         moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode,
         windDirection, windAndSpreadOrientationMode, firstFuelModelCoverage, firstFuelModelCoverageUnits, twoFuelModelsMethod, slope,
-        slopeUnits, aspect, canopyCover,canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        slopeUnits, aspect, canopyCover,canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     surfaceFire_.calculateMidflameWindSpeed();
 }
 
@@ -1072,13 +1073,13 @@ void Surface::updateSurfaceInputsForPalmettoGallbery(double moistureOneHour, dou
     double moistureLiveHerbaceous, double moistureLiveWoody, FractionUnits::FractionUnitsEnum moistureUnits, double windSpeed,
     SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double ageOfRough,
-    double heightOfUnderstory, double palmettoCoverage, double overstoryBasalArea, BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits, double slope, SlopeUnits::SlopeUnitsEnum slopeUnits,
-    double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
-{
+    double heightOfUnderstory, double palmettoCoverage, double overstoryBasalArea, BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits,
+    double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits,
+    double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits ) {
     surfaceInputs_.updateSurfaceInputsForPalmettoGallbery(moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode,
         ageOfRough, heightOfUnderstory, palmettoCoverage, overstoryBasalArea, basalAreaUnits, slope, slopeUnits, aspect, canopyCover, canopyUnits,
-        canopyHeight, canopyHeightUnits, crownRatio);
+        canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     surfaceFire_.calculateMidflameWindSpeed();
 }
 
@@ -1088,12 +1089,12 @@ void Surface::updateSurfaceInputsForWesternAspen(int aspenFuelModelNumber, doubl
     double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode,
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope,
     SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight,
-    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio,  FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     surfaceInputs_.updateSurfaceInputsForWesternAspen(aspenFuelModelNumber, aspenCuringLevel, curingLevelUnits, aspenFireSeverity,
         dbh, dbhUnits, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, moistureUnits,
         windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode, slope, slopeUnits, aspect,
-        canopyCover, canopyUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        canopyCover, canopyUnits, canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     surfaceFire_.calculateMidflameWindSpeed();
 }
 

--- a/src/behave/surface.h
+++ b/src/behave/surface.h
@@ -102,7 +102,7 @@ public:
     // SurfaceInputs setters
     void setCanopyHeight(double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits);
     void setCanopyCover(double canopyCover, FractionUnits::FractionUnitsEnum coverUnits);
-    void setCrownRatio(double crownRatio);
+    void setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setElapsedTime(double elapsedTime, TimeUnits::TimeUnitsEnum timeUnits);
     void setFuelModelNumber(int fuelModelNumber);
     void setMoistureOneHour(double moistureOneHour, FractionUnits::FractionUnitsEnum moistureUnits);
@@ -132,7 +132,7 @@ public:
         double moistureLiveHerbaceous, double moistureLiveWoody, FractionUnits::FractionUnitsEnum moistureUnits, double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits,
         WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect,
-        double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void updateSurfaceInputsForTwoFuelModels(int firstFuelModelNumber, int secondFuelModelNumber, double moistureOneHour,
         double moistureTenHour, double moistureHundredHour, double moistureLiveHerbaceous, double moistureLiveWoody,
         FractionUnits::FractionUnitsEnum moistureUnits, double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits,
@@ -140,7 +140,7 @@ public:
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double firstFuelModelCoverage,
         FractionUnits::FractionUnitsEnum firstFuelModelCoverageUnits, TwoFuelModelsMethod::TwoFuelModelsMethodEnum twoFuelModelsMethod,
         double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover,
-        FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
 
     // Palmetto-Gallberry setters
     void updateSurfaceInputsForPalmettoGallbery(double moistureOneHour, double moistureTenHour, double moistureHundredHour,
@@ -148,7 +148,7 @@ public:
         WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double ageOfRough, double heightOfUnderstory, double palmettoCoverage,
         double overstoryBasalArea, BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits, double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits,
-        double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setAgeOfRough(double ageOfRough);
     void setHeightOfUnderstory(double heightOfUnderstory, LengthUnits::LengthUnitsEnum heightUnits);
     void setPalmettoCoverage(double palmettoCoverage, FractionUnits::FractionUnitsEnum coverageUnits);
@@ -162,7 +162,7 @@ public:
         double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode,
         double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope,
         SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight,
-        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setAspenFuelModelNumber(int aspenFuelModelNumber);
     void setAspenCuringLevel(double aspenCuringLevel, FractionUnits::FractionUnitsEnum curingLevelUnits);
     void setAspenDBH(double dbh, LengthUnits::LengthUnitsEnum dbhUnits);
@@ -233,7 +233,7 @@ public:
     double getAspect() const;
     double getCanopyCover(FractionUnits::FractionUnitsEnum coverUnits) const;
     double getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeightUnits) const;
-    double getCrownRatio() const;
+    double getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const;
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum getWindAndSpreadOrientationMode() const;
     WindHeightInputMode::WindHeightInputModeEnum getWindHeightInputMode() const;
     WindAdjustmentFactorCalculationMethod::WindAdjustmentFactorCalculationMethodEnum getWindAdjustmentFactorCalculationMethod() const;

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -466,7 +466,7 @@ void SurfaceFire::calculateWindAdjustmentFactor()
 
     double canopyCover = surfaceInputs_->getCanopyCover(FractionUnits::Fraction);
     double canopyHeight = surfaceInputs_->getCanopyHeight(LengthUnits::Feet);
-    double crownRatio = surfaceInputs_->getCrownRatio();
+    double crownRatio = surfaceInputs_->getCrownRatio(FractionUnits::Fraction);
     double fuelbedDepth = surfaceFuelbedIntermediates_.getFuelbedDepth();
 
     WindAdjustmentFactorCalculationMethod::WindAdjustmentFactorCalculationMethodEnum windAdjustmentFactorCalculationMethod =

--- a/src/behave/surfaceInputs.cpp
+++ b/src/behave/surfaceInputs.cpp
@@ -109,7 +109,7 @@ void SurfaceInputs::updateSurfaceInputs(int fuelModelNumber, double moistureOneH
     WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection, 
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope,
     SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits,
-    double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     setSlope(slope, slopeUnits);
     aspect_ = aspect;
@@ -141,7 +141,7 @@ void SurfaceInputs::updateSurfaceInputs(int fuelModelNumber, double moistureOneH
 
     setCanopyCover(canopyCover, fractionUnits);
     setCanopyHeight(canopyHeight, canopyHeightUnits);
-    setCrownRatio(crownRatio);
+    setCrownRatio(crownRatio, crownRatioUnits);
 }
 
 void  SurfaceInputs::updateSurfaceInputsForTwoFuelModels(int firstfuelModelNumber, int secondFuelModelNumber,
@@ -150,13 +150,13 @@ void  SurfaceInputs::updateSurfaceInputsForTwoFuelModels(int firstfuelModelNumbe
     WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double firstFuelModelCoverage, 
     FractionUnits::FractionUnitsEnum firstFuelModelCoverageUnits, TwoFuelModelsMethod::TwoFuelModelsMethodEnum twoFuelModelsMethod, double slope, SlopeUnits::SlopeUnitsEnum slopeUnits,
-    double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio,
+    FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     int fuelModelNumber = firstfuelModelNumber;
     updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, 
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode,
-        slope, slopeUnits,
-        aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        slope, slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, crownRatioUnits);
     setSecondFuelModelNumber(secondFuelModelNumber);
     setTwoFuelModelsFirstFuelModelCoverage(firstFuelModelCoverage, firstFuelModelCoverageUnits);
     isUsingTwoFuelModels_ = true;
@@ -169,12 +169,12 @@ void  SurfaceInputs::updateSurfaceInputsForPalmettoGallbery(double moistureOneHo
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode,
     double ageOfRough, double heightOfUnderstory, double palmettoCoverage, double overstoryBasalArea, BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits,
     double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight,
-    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio,FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     updateSurfaceInputs(0, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection,
         windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, canopyUnits, canopyHeight, canopyHeightUnits,
-        crownRatio);
+        crownRatio, crownRatioUnits);
 
     setPalmettoGallberryAgeOfRough(ageOfRough);
     setPalmettoGallberryHeightOfUnderstory(heightOfUnderstory, canopyHeightUnits);
@@ -188,12 +188,12 @@ void SurfaceInputs::updateSurfaceInputsForWesternAspen(int aspenFuelModelNumber,
     double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, 
     double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode,
     double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight,
-    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio)
+    LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
     updateSurfaceInputs(0, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection,
         windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, canopyUnits, canopyHeight, canopyHeightUnits,
-        crownRatio);
+        crownRatio, crownRatioUnits);
 
     setAspenFuelModelNumber(aspenFuelModelNumber);
     setAspenCuringLevel(aspenCuringLevel, curingLevelUnits);
@@ -242,9 +242,9 @@ void SurfaceInputs::setCanopyHeight(double canopyHeight, LengthUnits::LengthUnit
     canopyHeight_ = LengthUnits::toBaseUnits(canopyHeight, canopyHeightUnits);
 }
 
-void SurfaceInputs::setCrownRatio(double crownRatio)
+void SurfaceInputs::setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits)
 {
-    crownRatio_ = crownRatio;
+    crownRatio_ = FractionUnits::toBaseUnits(crownRatio, crownRatioUnits);
 }
 
 void SurfaceInputs::setWindAndSpreadOrientationMode(WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode)
@@ -551,9 +551,9 @@ double SurfaceInputs::getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeightU
     return canopyHeight_;
 }
 
-double SurfaceInputs::getCrownRatio() const
+double SurfaceInputs::getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const
 {
-    return crownRatio_;
+    return FractionUnits::fromBaseUnits(crownRatio_, crownRatioUnits);
 }
 
 bool SurfaceInputs::getIsUsingWesternAspen() const

--- a/src/behave/surfaceInputs.h
+++ b/src/behave/surfaceInputs.h
@@ -48,7 +48,7 @@ public:
         SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, 
         double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, 
         double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits,
-        double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setFuelModelNumber(int fuelModelNumber);
     void setMoistureOneHour(double moistureOneHour, FractionUnits::FractionUnitsEnum moistureUnits);
     void setMoistureTenHour(double moistureTenHour, FractionUnits::FractionUnitsEnum moistureUnits);
@@ -69,7 +69,7 @@ public:
     void setWindHeightInputMode(WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode);
     void setCanopyCover(double canopyCover, FractionUnits::FractionUnitsEnum fractionUnits);
     void setCanopyHeight(double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits);
-    void setCrownRatio(double crownRatio);
+    void setCrownRatio(double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setUserProvidedWindAdjustmentFactor(double userProvidedWindAdjustmentFactor);
     void setWindAdjustmentFactorCalculationMethod(WindAdjustmentFactorCalculationMethod::WindAdjustmentFactorCalculationMethodEnum windAdjustmentFactorCalculationMethod);
     void setElapsedTime(double elapsedTime, TimeUnits::TimeUnitsEnum timeUnits);
@@ -92,7 +92,7 @@ public:
     double getAspect() const;
     double getCanopyCover(FractionUnits::FractionUnitsEnum fractionUnits) const;
     double getCanopyHeight(LengthUnits::LengthUnitsEnum canopyHeightUnits) const;
-    double getCrownRatio() const;
+    double getCrownRatio(FractionUnits::FractionUnitsEnum crownRatioUnits) const;
     WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum getWindAndSpreadOrientationMode() const;
     WindHeightInputMode::WindHeightInputModeEnum getWindHeightInputMode() const;
     double getUserProvidedWindAdjustmentFactor() const;
@@ -130,7 +130,8 @@ public:
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double firstFuelModelCoverage, 
         FractionUnits::FractionUnitsEnum firstFuelModelCoverageUnits, TwoFuelModelsMethod::TwoFuelModelsMethodEnum twoFuelModelsMethod, 
         double slope, SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover,
-        FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        FractionUnits::FractionUnitsEnum canopyCoverUnits, double canopyHeight, LengthUnits::LengthUnitsEnum canopyHeightUnits,
+        double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setFirstFuelModelNumber(int firstFuelModelNumber);
     void setSecondFuelModelNumber(int secondFuelModelNumber);
     void setTwoFuelModelsMethod(TwoFuelModelsMethod::TwoFuelModelsMethodEnum twoFuelModelsMethod);
@@ -149,8 +150,8 @@ public:
         SpeedUnits::SpeedUnitsEnum windSpeedUnits,WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, double windDirection,
         WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double ageOfRough,
         double heightOfUnderstory, double palmettoCoverage, double overstoryBasalArea, BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits, double slope,
-       SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight,
-        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum coverUnits, double canopyHeight,
+        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setPalmettoGallberryAgeOfRough(double ageOfRough);
     void setPalmettoGallberryHeightOfUnderstory(double heightOfUnderstory, LengthUnits::LengthUnitsEnum heightUnits);
     void setPalmettoGallberryPalmettoCoverage(double palmettoCoverage, FractionUnits::FractionUnitsEnum fractionUnits);
@@ -171,7 +172,7 @@ public:
         double windSpeed, SpeedUnits::SpeedUnitsEnum windSpeedUnits, WindHeightInputMode::WindHeightInputModeEnum windHeightInputMode, 
         double windDirection, WindAndSpreadOrientationMode::WindAndSpreadOrientationModeEnum windAndSpreadOrientationMode, double slope, 
         SlopeUnits::SlopeUnitsEnum slopeUnits, double aspect, double canopyCover, FractionUnits::FractionUnitsEnum canopyUnits, double canopyHeight,
-        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio);
+        LengthUnits::LengthUnitsEnum canopyHeightUnits, double crownRatio, FractionUnits::FractionUnitsEnum crownRatioUnits);
     void setAspenFuelModelNumber(int aspenFuelModelNumber);
     void setAspenCuringLevel(double aspenCuringLevel, FractionUnits::FractionUnitsEnum fractionUnits);
     void setAspenDBH(double dbh, LengthUnits::LengthUnitsEnum dbhUnits);

--- a/src/rawsBatch/behaveRawsBatch.cpp
+++ b/src/rawsBatch/behaveRawsBatch.cpp
@@ -401,7 +401,7 @@ int main(int argc, char *argv[])
                 WindHeightInputMode::DirectMidflame, windDirection,
                 WindAndSpreadOrientationMode::RelativeToNorth, slope,
                 SlopeUnits::Degrees, aspect, canopyCover, CoverUnits::Percent,
-                canopyHeight, LengthUnits::Feet, crownRatio);
+                canopyHeight, LengthUnits::Feet, crownRatio, FractionUnits::Fraction);
             // Calculate spread rate and flame length
             behave.surface.doSurfaceRunInDirectionOfMaxSpread();
             // Get the surface fire spread rate

--- a/src/testBehave/testBehave.cpp
+++ b/src/testBehave/testBehave.cpp
@@ -144,7 +144,7 @@ void setSurfaceInputsForGS4LowMoistureScenario(BehaveRun& behaveRun)
 
     behaveRun.surface.updateSurfaceInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode,
-        slope, slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        slope, slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
 }
 
 void setSurfaceInputsForTwoFuelModelsLowMoistureScenario(BehaveRun& behaveRun)
@@ -177,7 +177,7 @@ void setSurfaceInputsForTwoFuelModelsLowMoistureScenario(BehaveRun& behaveRun)
     behaveRun.surface.updateSurfaceInputsForTwoFuelModels(firstFuelModelNumber, secondFuelModelNumber, moistureOneHour, moistureTenHour, 
         moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode,
         windDirection, windAndSpreadOrientationMode, firstFuelModelCoverage, firstFuelModelCoverageUnits, twoFuelModelsMethod, slope, 
-        slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+                                                          slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
 }
 
 void setCrownInputsLowMoistureScenario(BehaveRun& behaveRun)
@@ -212,7 +212,7 @@ void setCrownInputsLowMoistureScenario(BehaveRun& behaveRun)
     behaveRun.crown.updateCrownInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureFoliar, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection, 
         windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits, canopyHeight, canopyBaseHeight, canopyHeightUnits,
-        crownRatio, canopyBulkDensity, canopyBulkDensityUnits);
+     crownRatio, FractionUnits::Fraction, canopyBulkDensity, canopyBulkDensityUnits);
 }
 
 bool areClose(const double observed, const double expected, const double epsilon)
@@ -629,7 +629,7 @@ void testPalmettoGallberry(TestInfo& testInfo, BehaveRun& behaveRun)
     BasalAreaUnits::BasalAreaUnitsEnum basalAreaUnits = BasalAreaUnits::SquareFeetPerAcre;
     behaveRun.surface.updateSurfaceInputsForPalmettoGallbery(moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, moistureUnits,
         windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode, ageOfRough, heightOfUnderstory, palmetoCoverage, overstoryBasalArea, basalAreaUnits,
-        slope, slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        slope, slopeUnits, aspect, canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
     behaveRun.surface.doSurfaceRunInDirectionOfMaxSpread();
     double observedSurfaceFireSpreadRate = roundToSixDecimalPlaces(behaveRun.surface.getSpreadRate(SpeedUnits::ChainsPerHour));
     double expectedSurfaceFireSpreadRate = 12.521131;
@@ -670,7 +670,7 @@ void testWesternAspen(TestInfo& testInfo, BehaveRun& behaveRun)
     behaveRun.surface.updateSurfaceInputsForWesternAspen(aspenFuelModel, aspenCuringLevel, curingLevelUnits, aspenFireSeverity, dbh, dbhUnits,
         moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous, moistureLiveWoody, mositureUnits,
         windSpeed, windSpeedUnits, windHeightInputMode, windDirection, windAndSpreadOrientationMode, slope, slopeUnits, aspect,
-        canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio);
+        canopyCover, canopyCoverUnits, canopyHeight, canopyHeightUnits, crownRatio, FractionUnits::Fraction);
     behaveRun.surface.doSurfaceRunInDirectionOfMaxSpread();
     double observedSurfaceFireSpreadRate = roundToSixDecimalPlaces(behaveRun.surface.getSpreadRate(SpeedUnits::ChainsPerHour));
     double expectedSurfaceFireSpreadRate = 0.847629;
@@ -1197,7 +1197,7 @@ void testCrownModuleScottAndReinhardt(TestInfo& testInfo, BehaveRun& behaveRun)
     behaveRun.crown.updateCrownInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureFoliar, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection,
         windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits, canopyHeight, canopyBaseHeight, canopyHeightUnits,
-        crownRatio, canopyBulkDensity, canopyBulkDensityUnits);
+        crownRatio, FractionUnits::Fraction, canopyBulkDensity, canopyBulkDensityUnits);
 
     testName = "Test Scott and Reinhardt crown fire spread rate";
     behaveRun.crown.doCrownRunScottAndReinhardt();
@@ -1276,7 +1276,7 @@ void testCrownModuleScottAndReinhardt(TestInfo& testInfo, BehaveRun& behaveRun)
     behaveRun.crown.updateCrownInputs(fuelModelNumber, moistureOneHour, moistureTenHour, moistureHundredHour, moistureLiveHerbaceous,
         moistureLiveWoody, moistureFoliar, moistureUnits, windSpeed, windSpeedUnits, windHeightInputMode, windDirection,
         windAndSpreadOrientationMode, slope, slopeUnits, aspect, canopyCover, coverUnits, canopyHeight, canopyBaseHeight, canopyHeightUnits,
-        crownRatio, canopyBulkDensity, canopyBulkDensityUnits);
+        crownRatio, FractionUnits::Fraction, canopyBulkDensity, canopyBulkDensityUnits);
 
     testName = "Test crown fire spread rate";
     behaveRun.crown.doCrownRunScottAndReinhardt();

--- a/src/testMortality/mortality_client.cpp
+++ b/src/testMortality/mortality_client.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
                 mortality.setTreeHeight(stod(TreeHeight), LengthUnits::Feet);
 
             if (!CrownRatio.empty() )
-                mortality.setCrownRatio(stod(CrownRatio, FractionUnits::Percent) / 100); // input as a fraction from 0.0 to 1.0
+                mortality.setCrownRatio(stod(CrownRatio) / 100, FractionUnits::Percent); // input as a fraction from 0.0 to 1.0
 
             if (!CrownScorchP.empty() )
                 mortality.setCrownDamage(stod(CrownScorchP));

--- a/src/testMortality/mortality_client.cpp
+++ b/src/testMortality/mortality_client.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
                 mortality.setTreeHeight(stod(TreeHeight), LengthUnits::Feet);
 
             if (!CrownRatio.empty() )
-                mortality.setCrownRatio(stod(CrownRatio) / 100); // input as a fraction from 0.0 to 1.0
+                mortality.setCrownRatio(stod(CrownRatio, FractionUnits::Percent) / 100); // input as a fraction from 0.0 to 1.0
 
             if (!CrownScorchP.empty() )
                 mortality.setCrownDamage(stod(CrownScorchP));
@@ -346,7 +346,7 @@ int main(int argc, char *argv[])
                     {
                         std::cout << "Error, missing required input " << fieldNameStrings[i] << "\n";
                     }
-                    if((currentRequiredFieldName == RequiredFieldNames::crown_ratio) && mortality.getCrownRatio() < 0)
+                    if((currentRequiredFieldName == RequiredFieldNames::crown_ratio) && mortality.getCrownRatio(FractionUnits::Fraction) < 0)
                     {
                         std::cout << "Error, missing required input " << fieldNameStrings[i] << "\n";
                     }

--- a/src/testMortality/mortality_client.cpp
+++ b/src/testMortality/mortality_client.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
                 mortality.setTreeHeight(stod(TreeHeight), LengthUnits::Feet);
 
             if (!CrownRatio.empty() )
-                mortality.setCrownRatio(stod(CrownRatio) / 100, FractionUnits::Percent); // input as a fraction from 0.0 to 1.0
+                mortality.setCrownRatio(stod(CrownRatio) / 100, FractionUnits::Fraction); // input as a fraction from 0.0 to 1.0
 
             if (!CrownScorchP.empty() )
                 mortality.setCrownDamage(stod(CrownScorchP));


### PR DESCRIPTION
-------

## Purpose

Make setters an getters for crownRatio consistent with others, requiring a units param.


## Related Issues
BHP1-986

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing