### PR TITLE
Fix calculateForwardSpreadRate and Add Tests Reproducible in behave6

### DIFF
--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -276,7 +276,12 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
 
     maxFlameLength_ = getFlameLength(); // Used by SAFETY Module
 
-    spreadRateInDirectionOfInterest_ = calculateSpreadRateAtVector(directionOfInterest, directionMode);
+    if (hasDirectionOfInterest) // propposed solution
+    {
+        spreadRateInDirectionOfInterest_ = calculateSpreadRateAtVector(directionOfInterest, directionMode);
+    }
+
+    std::cout << "spreadRateInDirectionOfInterest_:" << spreadRateInDirectionOfInterest_ << "\n";
 
     if (!hasDirectionOfInterest) // If needed, calculate spread rate in arbitrary direction of interest
     {

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -276,7 +276,7 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
 
     maxFlameLength_ = getFlameLength(); // Used by SAFETY Module
 
-    if (hasDirectionOfInterest) // propposed solution
+    if (hasDirectionOfInterest)
     {
         spreadRateInDirectionOfInterest_ = calculateSpreadRateAtVector(directionOfInterest, directionMode);
     }

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -276,14 +276,11 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
 
     maxFlameLength_ = getFlameLength(); // Used by SAFETY Module
 
-    if (hasDirectionOfInterest)
+    if (hasDirectionOfInterest) // If needed, calculate spread rate in arbitrary direction of interest
     {
         spreadRateInDirectionOfInterest_ = calculateSpreadRateAtVector(directionOfInterest, directionMode);
     }
-
-    std::cout << "spreadRateInDirectionOfInterest_:" << spreadRateInDirectionOfInterest_ << "\n";
-
-    if (!hasDirectionOfInterest) // If needed, calculate spread rate in arbitrary direction of interest
+    else
     {
         spreadRateInDirectionOfInterest_ = forwardSpreadRate_;
     }


### PR DESCRIPTION
-------

## Purpose

The `calculateSpreadRateAtVector` is being called during a `doSurfaceInDirectionOfMaxSpread` run and wrongfully updating the flame length and fireline intensity.

This PR:
1. Fixes this logic
2. Updates tests so that it can be reproduced using behave6 application

## Related Issues
BHP1-999

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing
1. make
2. make test
3. Ensure all tests pass
4. Recreate the tests updated in the MR in behave6 and ensure the values are matching.