### PR TITLE
[BHP1-994] Add New Outputs in the Direction of Interest

### DIFF
--- a/src/behave/surface.cpp
+++ b/src/behave/surface.cpp
@@ -235,6 +235,11 @@ double Surface::getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) co
     return LengthUnits::fromBaseUnits(surfaceFire_.getFlameLength(), flameLengthUnits);
 }
 
+double Surface::getDirectionOfInterestFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
+{
+    return LengthUnits::fromBaseUnits(surfaceFire_.getDirectionOfInterestFlameLength(), flameLengthUnits);
+}
+
 double Surface::getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
 {
   return LengthUnits::fromBaseUnits(surfaceFire_.getBackingFlameLength(), flameLengthUnits);
@@ -263,6 +268,12 @@ double Surface::getHeadingToBackingRatio() const
 double Surface::getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
 {
     return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getFirelineIntensity(), firelineIntensityUnits);
+}
+
+double Surface::getDirectionOfInterestFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
+{
+    return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getDirectionOfInterestFirelineIntensity(),
+                                                 firelineIntensityUnits);
 }
 
 double Surface::getBackingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const

--- a/src/behave/surface.cpp
+++ b/src/behave/surface.cpp
@@ -235,9 +235,9 @@ double Surface::getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) co
     return LengthUnits::fromBaseUnits(surfaceFire_.getFlameLength(), flameLengthUnits);
 }
 
-double Surface::getDirectionOfInterestFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
+double Surface::getFlameLengthInDirectionOfInterest(LengthUnits::LengthUnitsEnum flameLengthUnits) const
 {
-    return LengthUnits::fromBaseUnits(surfaceFire_.getDirectionOfInterestFlameLength(), flameLengthUnits);
+    return LengthUnits::fromBaseUnits(surfaceFire_.getFlameLengthInDirectionOfInterest(), flameLengthUnits);
 }
 
 double Surface::getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const
@@ -270,9 +270,9 @@ double Surface::getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUn
     return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getFirelineIntensity(), firelineIntensityUnits);
 }
 
-double Surface::getDirectionOfInterestFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
+double Surface::getFirelineIntensityInDirectionOfInterest(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const
 {
-    return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getDirectionOfInterestFirelineIntensity(),
+    return FirelineIntensityUnits::fromBaseUnits(surfaceFire_.getFirelineIntensityInDirectionOfInterest(),
                                                  firelineIntensityUnits);
 }
 

--- a/src/behave/surface.h
+++ b/src/behave/surface.h
@@ -69,14 +69,14 @@ public:
     double getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getFlankingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
-    double getDirectionOfInterestFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
+    double getFlameLengthInDirectionOfInterest(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;
     double getHeadingToBackingRatio() const;
     double getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getBackingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getFlankingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
-    double getDirectionOfInterestFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
+    double getFirelineIntensityInDirectionOfInterest(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getHeatPerUnitArea(HeatPerUnitAreaUnits::HeatPerUnitAreaUnitsEnum heatPerUnitAreaUnits) const;
     double getMidflameWindspeed(SpeedUnits::SpeedUnitsEnum windSpeedUnits) const;
     double getResidenceTime(TimeUnits::TimeUnitsEnum timeUnits) const;

--- a/src/behave/surface.h
+++ b/src/behave/surface.h
@@ -69,12 +69,14 @@ public:
     double getFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getBackingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getFlankingFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
+    double getDirectionOfInterestFlameLength(LengthUnits::LengthUnitsEnum flameLengthUnits) const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;
     double getHeadingToBackingRatio() const;
     double getFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getBackingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getFlankingFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
+    double getDirectionOfInterestFirelineIntensity(FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits) const;
     double getHeatPerUnitArea(HeatPerUnitAreaUnits::HeatPerUnitAreaUnitsEnum heatPerUnitAreaUnits) const;
     double getMidflameWindspeed(SpeedUnits::SpeedUnitsEnum windSpeedUnits) const;
     double getResidenceTime(TimeUnits::TimeUnitsEnum timeUnits) const;

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -612,7 +612,7 @@ double SurfaceFire::getFlankingFirelineIntensity() const
   return flankingFirelineIntensity_;
 }
 
-double SurfaceFire::getDirectionOfInterestFirelineIntensity() const
+double SurfaceFire::getFirelineIntensityInDirectionOfInterest() const
 {
     return directionOfInterestFirelineIntensity_;
 }
@@ -632,7 +632,7 @@ double SurfaceFire::getFlankingFlameLength() const
   return flankingFlameLength_;
 }
 
-double SurfaceFire::getDirectionOfInterestFlameLength() const
+double SurfaceFire::getFlameLengthInDirectionOfInterest() const
 {
     return directionOfInterestFlameLength_;
 }

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -221,7 +221,6 @@ void SurfaceFire::calculateFlameLengths()
                                                FirelineIntensityUnits::BtusPerFootPerSecond,
                                                LengthUnits::Feet);
 
-
     backingFlameLength_ = calculateFlameLength(backingFirelineIntensity_,
                                                FirelineIntensityUnits::BtusPerFootPerSecond,
                                                LengthUnits::Feet);
@@ -313,7 +312,7 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
         surfaceFuelbedIntermediates_.calculateWesternAspenMortality(forwardFlameLength_);
     }
 
-    maxFlameLength_ = forwardSpreadRate_; // Used by SAFETY Module
+    maxFlameLength_ = forwardFlameLength_; // Used by SAFETY Module
     calculateHeatSource();
 
     if (hasDirectionOfInterest)

--- a/src/behave/surfaceFire.cpp
+++ b/src/behave/surfaceFire.cpp
@@ -84,14 +84,22 @@ void SurfaceFire::initializeMembers()
     directionOfMaxSpread_ = 0.0;
     noWindNoSlopeSpreadRate_ = 0.0;
     forwardSpreadRate_ = 0.0;
+    backingSpreadRate_ = 0.0;
+    flankingSpreadRate_ = 0.0;
+    spreadRateInDirectionOfInterest_ = 0.0;
     heatPerUnitArea_ = 0.0;
     fireLengthToWidthRatio_ = 1.0;
     residenceTime_ = 0.0;
     reactionIntensity_ = 0.0;
-    firelineIntensity_ = 0.0;
-    flameLength_ = 0.0;
+    forwardFirelineIntensity_ = 0.0;
+    backingFirelineIntensity_ = 0.0;
+    flankingFirelineIntensity_ = 0.0;
+    directionOfInterestFirelineIntensity_ = 0.0;
+    forwardFlameLength_ = 0.0;
+    backingFlameLength_ = 0.0;
+    flankingFlameLength_ = 0.0;
+    directionOfInterestFlameLength_ = 0.0;
     maxFlameLength_ = 0.0;
-    backingSpreadRate_ = 0.0;
     scorchHeight_ = 0.0;
 
     midflameWindSpeed_ = 0.0;
@@ -120,15 +128,22 @@ void SurfaceFire::memberwiseCopyAssignment(const SurfaceFire& rhs)
     directionOfMaxSpread_ = rhs.directionOfMaxSpread_;
     noWindNoSlopeSpreadRate_ = rhs.noWindNoSlopeSpreadRate_;
     forwardSpreadRate_ = rhs.forwardSpreadRate_;
+    backingSpreadRate_ = rhs.backingSpreadRate_;
+    flankingSpreadRate_ = rhs.flankingSpreadRate_;
     spreadRateInDirectionOfInterest_ = rhs.spreadRateInDirectionOfInterest_;
     heatPerUnitArea_ = rhs.heatPerUnitArea_;
     fireLengthToWidthRatio_ = rhs.fireLengthToWidthRatio_;
     residenceTime_ = rhs.residenceTime_;
     reactionIntensity_ = rhs.reactionIntensity_;
-    firelineIntensity_ = rhs.firelineIntensity_;
-    flameLength_ = rhs.flameLength_;
+    forwardFirelineIntensity_ = rhs.forwardFirelineIntensity_;
+    backingFirelineIntensity_ = rhs.backingFirelineIntensity_;
+    flankingFirelineIntensity_ = rhs.flankingFirelineIntensity_;
+    directionOfInterestFirelineIntensity_ = rhs.directionOfInterestFirelineIntensity_;
+    forwardFlameLength_ = rhs.forwardFlameLength_;
+    backingFlameLength_ = rhs.backingFlameLength_;
+    flankingFlameLength_ = rhs.flankingFlameLength_;
+    directionOfInterestFlameLength_ = rhs.directionOfInterestFlameLength_;
     maxFlameLength_ = rhs.maxFlameLength_;
-    backingSpreadRate_ = rhs.backingSpreadRate_;
     scorchHeight_ = rhs.scorchHeight_;
 
     midflameWindSpeed_ = rhs.midflameWindSpeed_;
@@ -153,22 +168,32 @@ void SurfaceFire::calculateResidenceTime()
         : (384. / sigma));
 }
 
-void SurfaceFire::calculateFirelineIntensity(double forwardSpreadRate)
+double SurfaceFire::calculateFirelineIntensity(double spreadRate,
+                                               SpeedUnits::SpeedUnitsEnum speedUnits,
+                                               FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits)
 {
     double secondsPerMinute = 60.0; // for converting feet per minute to feet per second
-    firelineIntensity_ = forwardSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
+    double firelineIntensity = SpeedUnits::toBaseUnits(spreadRate, speedUnits) * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
+    return FirelineIntensityUnits::fromBaseUnits(firelineIntensity, firelineIntensityUnits);
 }
 
-void SurfaceFire::calculateBackingFireFirelineIntensity(double backingSpreadRate)
+void SurfaceFire::calculateFirelineIntensities()
 {
-  double secondsPerMinute = 60.0; // for converting feet per minute to feet per second
-  backingFirelineIntensity_ = backingSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
-}
+    forwardFirelineIntensity_ = calculateFirelineIntensity(forwardSpreadRate_,
+                                                           SpeedUnits::FeetPerMinute,
+                                                           FirelineIntensityUnits::BtusPerFootPerSecond);
 
-void SurfaceFire::calculateFlankingFireFirelineIntensity(double flankingSpreadRate)
-{
-  double secondsPerMinute = 60.0; // for converting feet per minute to feet per second
-  flankingFirelineIntensity_ = flankingSpreadRate * reactionIntensity_ * (residenceTime_ / secondsPerMinute);
+    backingFirelineIntensity_ = calculateFirelineIntensity(backingSpreadRate_,
+                                                           SpeedUnits::FeetPerMinute,
+                                                           FirelineIntensityUnits::BtusPerFootPerSecond);
+
+    flankingFirelineIntensity_ = calculateFirelineIntensity(flankingSpreadRate_,
+                                                            SpeedUnits::FeetPerMinute,
+                                                            FirelineIntensityUnits::BtusPerFootPerSecond);
+
+    directionOfInterestFirelineIntensity_ = calculateFirelineIntensity(spreadRateInDirectionOfInterest_,
+                                                                       SpeedUnits::FeetPerMinute,
+                                                                       FirelineIntensityUnits::BtusPerFootPerSecond);
 }
 
 void SurfaceFire::skipCalculationForZeroLoad()
@@ -176,39 +201,49 @@ void SurfaceFire::skipCalculationForZeroLoad()
     initializeMembers();
 }
 
-void SurfaceFire::calculateFlameLength()
+double SurfaceFire::calculateFlameLength(double firelineIntensity,
+                                         FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits,
+                                         LengthUnits::LengthUnitsEnum flameLengthUnits)
 {
+    firelineIntensity = FirelineIntensityUnits::toBaseUnits(firelineIntensity, firelineIntensityUnits);
+
+
     // Byram 1959, Albini 1976
-    flameLength_ = ((firelineIntensity_ < 1.0e-07)
-        ? (0.0)
-        : (0.45 * pow(firelineIntensity_, 0.46)));
-}
-
-void SurfaceFire::calculateBackingFlameLength()
-{
-  // Byram 1959, Albini 1976
-  backingFlameLength_ = ((backingFirelineIntensity_ < 1.0e-07)
-                         ? (0.0)
-                         : (0.45 * pow(backingFirelineIntensity_, 0.46)));
-}
-
-void SurfaceFire::calculateFlankingFlameLength()
-{
-  // Byram 1959, Albini 1976
-  flankingFlameLength_ = ((flankingFirelineIntensity_ < 1.0e-07)
+    double flameLength = ((firelineIntensity < 1.0e-07)
                           ? (0.0)
-                          : (0.45 * pow(flankingFirelineIntensity_, 0.46)));
+                          : (0.45 * pow(firelineIntensity, 0.46)));
+    return LengthUnits::fromBaseUnits(flameLength, flameLengthUnits);
+}
+
+void SurfaceFire::calculateFlameLengths()
+{
+    forwardFlameLength_ = calculateFlameLength(forwardFirelineIntensity_,
+                                               FirelineIntensityUnits::BtusPerFootPerSecond,
+                                               LengthUnits::Feet);
+
+
+    backingFlameLength_ = calculateFlameLength(backingFirelineIntensity_,
+                                               FirelineIntensityUnits::BtusPerFootPerSecond,
+                                               LengthUnits::Feet);
+
+    flankingFlameLength_ = calculateFlameLength(flankingFirelineIntensity_,
+                                                FirelineIntensityUnits::BtusPerFootPerSecond,
+                                                LengthUnits::Feet);
+
+    directionOfInterestFlameLength_ = calculateFlameLength(directionOfInterestFirelineIntensity_,
+                                                           FirelineIntensityUnits::BtusPerFootPerSecond,
+                                                           LengthUnits::Feet);
 }
 
 void SurfaceFire::calculateScorchHeight()
 {
     const double airTemperature = surfaceInputs_->getAirTemperature(TemperatureUnits::Fahrenheit);
     const double windSpeed = surfaceInputs_->getWindSpeed(SpeedUnits::MilesPerHour);
-    scorchHeight_ = ((firelineIntensity_ < 1.0e-07)
+    scorchHeight_ = ((forwardFirelineIntensity_ < 1.0e-07)
         ? (0.0)
         : ((63.0 / (140.0 - airTemperature))
-            * pow(firelineIntensity_, 1.166667)
-            / sqrt(firelineIntensity_ + (windSpeed * windSpeed * windSpeed))
+            * pow(forwardFirelineIntensity_, 1.166667)
+            / sqrt(forwardFirelineIntensity_ + (windSpeed * windSpeed * windSpeed))
             ));
 }
 
@@ -259,23 +294,6 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
     backingSpreadRate_ = size_->getBackingSpreadRate(SpeedUnits::FeetPerMinute);
     flankingSpreadRate_ = size_->getFlankingSpreadRate(SpeedUnits::FeetPerMinute);
 
-    calculateHeatPerUnitArea();
-    calculateFirelineIntensity(forwardSpreadRate_);
-    calculateBackingFireFirelineIntensity(backingSpreadRate_);
-    calculateFlankingFireFirelineIntensity(flankingSpreadRate_);
-
-    calculateFlameLength();
-    calculateBackingFlameLength();
-    calculateFlankingFlameLength();
-
-    bool isUsingWesternAspen = surfaceInputs_->getIsUsingWesternAspen();
-    if (isUsingWesternAspen)
-    {
-        surfaceFuelbedIntermediates_.calculateWesternAspenMortality(flameLength_);
-    }
-
-    maxFlameLength_ = getFlameLength(); // Used by SAFETY Module
-
     if (hasDirectionOfInterest) // If needed, calculate spread rate in arbitrary direction of interest
     {
         spreadRateInDirectionOfInterest_ = calculateSpreadRateAtVector(directionOfInterest, directionMode);
@@ -285,9 +303,27 @@ double SurfaceFire::calculateForwardSpreadRate(int fuelModelNumber, bool hasDire
         spreadRateInDirectionOfInterest_ = forwardSpreadRate_;
     }
 
+    calculateHeatPerUnitArea();
+    calculateFirelineIntensities();
+    calculateFlameLengths();
+
+    bool isUsingWesternAspen = surfaceInputs_->getIsUsingWesternAspen();
+    if (isUsingWesternAspen)
+    {
+        surfaceFuelbedIntermediates_.calculateWesternAspenMortality(forwardFlameLength_);
+    }
+
+    maxFlameLength_ = forwardSpreadRate_; // Used by SAFETY Module
     calculateHeatSource();
 
-    return spreadRateInDirectionOfInterest_;
+    if (hasDirectionOfInterest)
+    {
+        return spreadRateInDirectionOfInterest_;
+    }
+    else
+    {
+        return forwardSpreadRate_;
+    }
 }
 
 double SurfaceFire::calculateSpreadRateAtVector(double directionOfInterest, SurfaceFireSpreadDirectionMode::SurfaceFireSpreadDirectionModeEnum directionMode)
@@ -334,11 +370,8 @@ double SurfaceFire::calculateSpreadRateAtVector(double directionOfInterest, Surf
         double cosBeta = cos(radians);
         double sinBeta = sin(radians);
 
-        rosVector = (g * cos(radians)) + sqrt((f * f * cosBeta * cosBeta) + (h * h * sinBeta * sinBeta));
-
         // rosVector perpendicular to perimeter at angle beta used to calculate fireline intensity and flame length
-        calculateFirelineIntensity(rosVector);
-        calculateFlameLength();
+        rosVector = (g * cos(radians)) + sqrt((f * f * cosBeta * cosBeta) + (h * h * sinBeta * sinBeta));
 
         if (directionMode == SurfaceFireSpreadDirectionMode::FromIgnitionPoint)
         {
@@ -566,7 +599,7 @@ double SurfaceFire::convertDirectionOfSpreadToRelativeToNorth(double directionOf
 
 double SurfaceFire::getFirelineIntensity() const
 {
-    return firelineIntensity_;
+    return forwardFirelineIntensity_;
 }
 
 double SurfaceFire::getBackingFirelineIntensity() const
@@ -579,9 +612,14 @@ double SurfaceFire::getFlankingFirelineIntensity() const
   return flankingFirelineIntensity_;
 }
 
+double SurfaceFire::getDirectionOfInterestFirelineIntensity() const
+{
+    return directionOfInterestFirelineIntensity_;
+}
+
 double SurfaceFire::getFlameLength() const
 {
-    return flameLength_;
+    return forwardFlameLength_;
 }
 
 double SurfaceFire::getBackingFlameLength() const
@@ -592,6 +630,11 @@ double SurfaceFire::getBackingFlameLength() const
 double SurfaceFire::getFlankingFlameLength() const
 {
   return flankingFlameLength_;
+}
+
+double SurfaceFire::getDirectionOfInterestFlameLength() const
+{
+    return directionOfInterestFlameLength_;
 }
 
 double SurfaceFire::getMaxFlameLength() const
@@ -904,12 +947,12 @@ void SurfaceFire::setEffectiveWindSpeed(double effectiveWindSpeed)
 
 void SurfaceFire::setFirelineIntensity(double firelineIntensity)
 {
-    firelineIntensity_ = firelineIntensity;
+    forwardFirelineIntensity_ = firelineIntensity;
 }
 
 void SurfaceFire::setFlameLength(double flameLength)
 {
-    flameLength_ = flameLength;
+    forwardFlameLength_ = flameLength;
 }
 
 void SurfaceFire::setFireLengthToWidthRatio(double lengthToWidthRatio)

--- a/src/behave/surfaceFire.h
+++ b/src/behave/surfaceFire.h
@@ -62,11 +62,11 @@ public:
     double getFirelineIntensity() const;
     double getBackingFirelineIntensity() const;
     double getFlankingFirelineIntensity() const;
-    double getFirelineIntensityInDirectionOfInterest()const;
+    double getFirelineIntensityInDirectionOfInterest() const;
     double getFlameLength() const;
     double getBackingFlameLength() const;
     double getFlankingFlameLength() const;
-    double getFlameLengthInDirectionOfInterest()const;
+    double getFlameLengthInDirectionOfInterest() const;
     double getMaxFlameLength() const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;

--- a/src/behave/surfaceFire.h
+++ b/src/behave/surfaceFire.h
@@ -62,11 +62,11 @@ public:
     double getFirelineIntensity() const;
     double getBackingFirelineIntensity() const;
     double getFlankingFirelineIntensity() const;
-    double getDirectionOfInterestFirelineIntensity()const;
+    double getFirelineIntensityInDirectionOfInterest()const;
     double getFlameLength() const;
     double getBackingFlameLength() const;
     double getFlankingFlameLength() const;
-    double getDirectionOfInterestFlameLength()const;
+    double getFlameLengthInDirectionOfInterest()const;
     double getMaxFlameLength() const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;

--- a/src/behave/surfaceFire.h
+++ b/src/behave/surfaceFire.h
@@ -62,9 +62,11 @@ public:
     double getFirelineIntensity() const;
     double getBackingFirelineIntensity() const;
     double getFlankingFirelineIntensity() const;
+    double getDirectionOfInterestFirelineIntensity()const;
     double getFlameLength() const;
     double getBackingFlameLength() const;
     double getFlankingFlameLength() const;
+    double getDirectionOfInterestFlameLength()const;
     double getMaxFlameLength() const;
     double getFireLengthToWidthRatio() const;
     double getFireEccentricity() const;
@@ -135,6 +137,7 @@ public:
 
 protected:
     // Protected setters accessible to friend classes
+
     void setDirectionOfMaxSpread(double directionOFMaxSpread);
     void setEffectiveWindSpeed(double effectiveWindSpeed);
     void setFirelineIntensity(double firelineIntensity);
@@ -157,12 +160,14 @@ protected:
     void calculateHeatSource();
 
     void calculateResidenceTime();
-    void calculateFirelineIntensity(double forwardSpreadRate);
-    void calculateBackingFireFirelineIntensity(double backingSpreadRate);
-    void calculateFlankingFireFirelineIntensity(double flankingSpreadRate);
-    void calculateFlameLength();
-    void calculateBackingFlameLength();
-    void calculateFlankingFlameLength();
+    double calculateFirelineIntensity(double forwardSpreadRate,
+                                      SpeedUnits::SpeedUnitsEnum speedUnits,
+                                      FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits);
+    void calculateFirelineIntensities();
+    double calculateFlameLength(double firelineIntensity,
+                                FirelineIntensityUnits::FirelineIntensityUnitsEnum firelineIntensityUnits,
+                                LengthUnits::LengthUnitsEnum flameLengthUnits);
+    void calculateFlameLengths();
     void calculateScorchHeight();
     void calculateWindSpeedLimit();
     void calculateDirectionOfMaxSpread();
@@ -198,13 +203,15 @@ protected:
     double fireLengthToWidthRatio_;
     double residenceTime_;
     double reactionIntensity_;
-    double firelineIntensity_;
+    double forwardFirelineIntensity_;
     double backingFirelineIntensity_;
     double flankingFirelineIntensity_;
+    double directionOfInterestFirelineIntensity_;
     double maxFlameLength_;                                 // Flame length computed from spread rate in max direction, used in SAFETY
-    double flameLength_;
+    double forwardFlameLength_;
     double backingFlameLength_;
     double flankingFlameLength_;
+    double directionOfInterestFlameLength_;
     double heatSource_;
     double scorchHeight_;
 

--- a/src/testBehave/testBehave.cpp
+++ b/src/testBehave/testBehave.cpp
@@ -873,7 +873,7 @@ void testDirectionOfInterest(TestInfo& testInfo, BehaveRun& behaveRun)
     reportTestResult(testInfo, testName, observedSpreadRateInDirectionOfInterest, expectedSpreadRateInDirectionOfInterest, error_tolerance);
 
     testName = "Test perimeter spread direction mode upslope oriented mode, 20 foot wind, direction of interest 90 degrees from upslope, 45 degree wind flame length";
-    observedFlameLengthInDirectionOfInterest = roundToSixDecimalPlaces(behaveRun.surface.getFlameLength(LengthUnits::Feet));
+    observedFlameLengthInDirectionOfInterest = roundToSixDecimalPlaces(behaveRun.surface.getDirectionOfInterestFlameLength(LengthUnits::Feet));
     expectedFlameLengthInDirectionOfInterest = 6.5981480000000001;
     reportTestResult(testInfo, testName, observedFlameLengthInDirectionOfInterest, expectedFlameLengthInDirectionOfInterest, error_tolerance);
 

--- a/src/testBehave/testBehave.cpp
+++ b/src/testBehave/testBehave.cpp
@@ -873,7 +873,7 @@ void testDirectionOfInterest(TestInfo& testInfo, BehaveRun& behaveRun)
     reportTestResult(testInfo, testName, observedSpreadRateInDirectionOfInterest, expectedSpreadRateInDirectionOfInterest, error_tolerance);
 
     testName = "Test perimeter spread direction mode upslope oriented mode, 20 foot wind, direction of interest 90 degrees from upslope, 45 degree wind flame length";
-    observedFlameLengthInDirectionOfInterest = roundToSixDecimalPlaces(behaveRun.surface.getDirectionOfInterestFlameLength(LengthUnits::Feet));
+    observedFlameLengthInDirectionOfInterest = roundToSixDecimalPlaces(behaveRun.surface.getFlameLengthInDirectionOfInterest(LengthUnits::Feet));
     expectedFlameLengthInDirectionOfInterest = 6.5981480000000001;
     reportTestResult(testInfo, testName, observedFlameLengthInDirectionOfInterest, expectedFlameLengthInDirectionOfInterest, error_tolerance);
 


### PR DESCRIPTION
## Purpose

It was requested that the flame length and fireline intensity in the direction of interest was also calculated (separate from the heading outputs).

## Related Issues
BHP1-994

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing
1. run `make test`