### PR TITLE
[BHP1-1150] Remove setWindAdjustmentFactorCalculationMethod in Crown::doCrownRunRothermel()

### DIFF
--- a/src/behave/crown.cpp
+++ b/src/behave/crown.cpp
@@ -120,7 +120,6 @@ void Crown::doCrownRunRothermel()
     surfaceFuel_.setCrownRatio(crownRatio, FractionUnits::Fraction);
 
     // Step 1: Do surface run and store values needed for further calculations 
-    surfaceFuel_.setWindAdjustmentFactorCalculationMethod(WindAdjustmentFactorCalculationMethod::UseCrownRatio);
     surfaceFuel_.doSurfaceRunInDirectionOfMaxSpread(); // Crown ROS output given in direction of max spread 
     surfaceFireHeatPerUnitArea_ = surfaceFuel_.getHeatPerUnitArea(HeatPerUnitAreaUnits::BtusPerSquareFoot);
     surfaceFirelineIntensity_ = surfaceFuel_.getFirelineIntensity(FirelineIntensityUnits::BtusPerFootPerSecond);


### PR DESCRIPTION
-------

## Purpose


This setter is unecessary since in `surfaceInputs.cpp` https://github.com/firelab/behave/blob/931a022430e66c5cf1805a2d23538b61f8d7dfcb/src/behave/surfaceInputs.cpp#L77

The `windAdjustmentFactorCalculationMethod_` is already defaulted to `WindAdjustmentFactorCalculationMethod::UseCrownRatio`.

By Remove this we preserve the original code and it allows the Crown Module to be ran with `WindAdjustmentFactorCalculationMethod::UserInput` if it has been set.

## Related Issues
BHP1-1150

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing