### PR TITLE
[BHP1-1622] Initialize total fuel load accumulators to zero

### DIFF
--- a/src/behave/surfaceFuelbedIntermediates.cpp
+++ b/src/behave/surfaceFuelbedIntermediates.cpp
@@ -990,7 +990,7 @@ double SurfaceFuelbedIntermediates::getWeightedFuelLoadByLifeState(FuelLifeState
 }
 
 double SurfaceFuelbedIntermediates::getTotalLiveFuelLoad(LoadingUnits::LoadingUnitsEnum loadingUnits) const {
-    double totalLoad;
+    double totalLoad = 0.0;
     for (int i = 0; i < FuelConstants::MaxParticles; i++)
     {
         totalLoad = totalLoad + loadLive_[i];
@@ -999,7 +999,7 @@ double SurfaceFuelbedIntermediates::getTotalLiveFuelLoad(LoadingUnits::LoadingUn
 }
 
 double SurfaceFuelbedIntermediates::getTotalDeadFuelLoad(LoadingUnits::LoadingUnitsEnum loadingUnits) const {
-    double totalLoad;
+    double totalLoad = 0.0;
     for (int i = 0; i < FuelConstants::MaxParticles; i++)
     {
         totalLoad = totalLoad + loadDead_[i];


### PR DESCRIPTION
## Purpose

`SurfaceFuelbedIntermediates::getTotalLiveFuelLoad`/`getTotalDeadFuelLoad` sum onto an uninitialized local `totalLoad`, which reads as NaN in the Emscripten/WASM build. Initialize to zero.

## Related Issues
BHP1-1622

## Submission Checklist
- [x] Code compiles are passing (`make compile`)
- [x] Tests are passing (`make test`)

## Testing

1. Build the WASM bundle in `behave-app/behave-lib` (`make install`)
2. Create a `SIGSurface`, set fuel model `163`, and run `doSurfaceRun`
3. `getTotalDeadFuelLoad`/`getTotalLiveFuelLoad` (ton/ac) return `2.15`/`1.1` instead of `NaN`